### PR TITLE
Added support for opening JSON by URL parameter

### DIFF
--- a/src/components/form/OpenEvaluation.svelte
+++ b/src/components/form/OpenEvaluation.svelte
@@ -23,7 +23,6 @@
   const navigate = useNavigate();
 
   function handleOpenChange(event) {
-    
     var clearResult = true;
     if($interacted == true){
       var clearResult = window.confirm(TRANSLATED.CLEAR_WARNING);

--- a/src/components/form/OpenEvaluation.svelte
+++ b/src/components/form/OpenEvaluation.svelte
@@ -23,6 +23,7 @@
   const navigate = useNavigate();
 
   function handleOpenChange(event) {
+    
     var clearResult = true;
     if($interacted == true){
       var clearResult = window.confirm(TRANSLATED.CLEAR_WARNING);
@@ -55,20 +56,24 @@
   }
   
   function loadFromUrl() {
+    
     var clearResult = true;
-    if($interacted == true){
-      var clearResult = window.confirm(TRANSLATED.CLEAR_WARNING);
-    }
+    var queryString = window.location.search;
+    var urlParams = new URLSearchParams(queryString);
 
-    if(clearResult){
+    /*if($interacted == true){
+      var clearResult = window.confirm(TRANSLATED.CLEAR_WARNING);
+    }*/
+
+    if (urlParams.has("jsonUrl") && clearResult) {
+      
       loading = true;
-      
-      const queryString = window.location.search;
-      const urlParams = new URLSearchParams(queryString);
-      if(URLSearchParams.has('jsonUrl')) {
-        const jsonUrl = urlParams.get('jsonUrl').replace(/[^a-z0-9 \.,_-]/gim,"");
-        const json = JSON.parse(jsonUrl);
-      
+        
+        const jsonUrl = urlParams.get("jsonUrl");
+
+        const result=getJSON(jsonUrl);
+        const json = JSON.parse(result);
+        
         $evaluationStore
           .open(json)
           .then(() => {
@@ -77,11 +82,28 @@
             $interacted = true;
           })
           .finally(() => {
-            target.value = '';
+            //target.value = '';
             loading = false;
           });
       }
-    }
   }
+  
+  function getJSON(url) {
+        var resp ;
+        var xmlHttp ;
+
+        resp  = '' ;
+        xmlHttp = new XMLHttpRequest();
+
+        if(xmlHttp != null)
+        {
+            xmlHttp.open( "GET", url, false );
+            xmlHttp.send( null );
+            resp = xmlHttp.responseText;
+        }
+
+        return resp ;
+    }
+
   loadFromUrl();
 </script>

--- a/src/components/form/OpenEvaluation.svelte
+++ b/src/components/form/OpenEvaluation.svelte
@@ -65,10 +65,11 @@
       
       const queryString = window.location.search;
       const urlParams = new URLSearchParams(queryString);
-      const jsonUrl = urlParams.get('jsonUrl').replace(/[^a-z0-9 \.,_-]/gim,"");
-      const json = JSON.parse(jsonUrl);
+      if(URLSearchParams.has('jsonUrl')) {
+        const jsonUrl = urlParams.get('jsonUrl').replace(/[^a-z0-9 \.,_-]/gim,"");
+        const json = JSON.parse(jsonUrl);
       
-      $evaluationStore
+        $evaluationStore
           .open(json)
           .then(() => {
             $interactedOpenEvaluation = true;
@@ -79,7 +80,8 @@
             target.value = '';
             loading = false;
           });
-
+      }
     }
   }
+  loadFromUrl();
 </script>

--- a/src/components/form/OpenEvaluation.svelte
+++ b/src/components/form/OpenEvaluation.svelte
@@ -53,4 +53,33 @@
       event.target.value = ''
     }
   }
+  
+  function loadFromUrl() {
+    var clearResult = true;
+    if($interacted == true){
+      var clearResult = window.confirm(TRANSLATED.CLEAR_WARNING);
+    }
+
+    if(clearResult){
+      loading = true;
+      
+      const queryString = window.location.search;
+      const urlParams = new URLSearchParams(queryString);
+      const jsonUrl = urlParams.get('jsonUrl').replace(/[^a-z0-9 \.,_-]/gim,"");
+      const json = JSON.parse(jsonUrl);
+      
+      $evaluationStore
+          .open(json)
+          .then(() => {
+            $interactedOpenEvaluation = true;
+            navigate('/evaluation/define-scope');
+            $interacted = true;
+          })
+          .finally(() => {
+            target.value = '';
+            loading = false;
+          });
+
+    }
+  }
 </script>


### PR DESCRIPTION
I've modified the file `\src\components\form\OpenEvaluation.svelte` to add support for opening a JSON file by a URL parameter.

For example: 

> https://www.w3.org/WAI/eval/report-tool/?jsonUrl=https://domain.com/evaluation.json

This adds possibilities to add an default evaluation template or automate some processes from a back office.