### PR TITLE
Clarify development setup by adding default localhost URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We use [Svelte](https://svelte.dev/) so that we can express the code of this pro
 
 ### After first time
 
-1. For development, run `npm run dev`, this builds the project, serves the application on a local server so that you can look at it and watches for any changes you make to the code
+1. For development, run `npm run dev`, this builds the project, serves the application on a local server ([localhost:10001](http://localhost:10001) per default) so that you can look at it and watches for any changes you make to the code.
 2. To only build the application, run `npm run build`, this builds the project without serving it.
 
 ### Publishing in a sub folder


### PR DESCRIPTION
For people not aware of how Rollup works and that rollup-plugin-serve acts as local development server,
it is now easier to get started with the development environment, without the need to check the code
and Rollup documentation to find out, what the localhost port of the dev server is.