### PR TITLE
Pin `main.yml` rollup dependency to maintain node 12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version: '12.x'
     - run: npm install
-    - run: npm install --global rollup
+    - run: npm install --global rollup@2.79.1
     - run: export BASEPATH='/WAI/eval/report-tool' && npm run clean:build && rollup -c
     - run: cd build && ln -s index.html 404.html # symlink for GH pages fallback
     - name: Deploy 🚀

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Use Node.js '12.x'
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: '12.x'
     - run: npm install


### PR DESCRIPTION
This pins the globally installed rollup dependency during the `main.yml` workflow to [2.79.1](https://github.com/rollup/rollup/releases/tag/v2.79.1). This is the last version before [rollup dropped Node 12 support in v3](https://github.com/rollup/rollup/releases/tag/v3.0.0). This was causing failures when the workflow was triggered.

Also took the opportunity to update:
* actions/checkout
* actions/setup-node