### PR TITLE
Made sample delete button visible

### DIFF
--- a/src/components/form/Editable.svelte
+++ b/src/components/form/Editable.svelte
@@ -43,7 +43,7 @@
 
 <style>
   .Editable__Control--delete {
-    font-size: 1em;;
+    font-size: 1em;
     float: right;
     margin-left: 1em;
     margin-top: .25em;
@@ -51,6 +51,7 @@
     border: 0;
     background-color: transparent;
     color: currentColor;
+    width: 1em;
   }
   .Editable {
     background: var(--trans-line-grey);

--- a/src/components/form/Editable.svelte
+++ b/src/components/form/Editable.svelte
@@ -52,6 +52,7 @@
     background-color: transparent;
     color: currentColor;
     width: 1em;
+		display: inline-block;
   }
   .Editable {
     background: var(--trans-line-grey);


### PR DESCRIPTION
Made delete icon visible on "Structured Sample Web Pages" and "Randomly Selected Sample"

![image](https://github.com/w3c/wai-wcag-em-report-tool/assets/27073716/b4b2bfe5-0d23-4c1b-ba1e-04beab3f73f9)

Fixes #151 