### PR TITLE
Improve Translation Box

### DIFF
--- a/src/components/ui/Page.svelte
+++ b/src/components/ui/Page.svelte
@@ -9,9 +9,12 @@
       <h1>{title}</h1>
       {#if currentLocale.status === "draft"}
           <section id="translation-info" class="doc-note-translation" lang="en">
-            <h2 class="visuallyhidden">About this translation</h2>
-            <p>This volunteer translation is a <strong>draft</strong>. It contains English wording that will be translated soon.</p>
-            <p>See <a href="{`${$basepath}/acknowledgements`}">Acknowledgements</a> for all translators and contributors.</p>
+            <h2 class="visuallyhidden">{TRANSLATED.TRANSLATION_ABOUT}</h2>
+            <p>{@html TRANSLATED.TRANSLATION_DRAFT}</p>
+            {#if currentLocale.wcagStatus === "unofficial"}
+              <p>{@html TRANSLATED.TRANSLATION_UNOFFICIAL}</p>
+            {/if}
+            <p>{@html TRANSLATED.TRANSLATION_ACK}</p>
           </section>
       {/if}
       <slot />
@@ -27,9 +30,12 @@
       <h1>{title}</h1>
       {#if currentLocale.status === "draft"}
           <section id="translation-info" class="doc-note-translation" lang="en">
-            <h2 class="visuallyhidden">About this translation</h2>
-            <p>This volunteer translation is a <strong>draft</strong>. It contains English wording that will be translated soon.</p>
-            <p>See <a href="{`${$basepath}/acknowledgements`}">Acknowledgements</a> for all translators and contributors.</p>
+            <h2 class="visuallyhidden">{TRANSLATED.TRANSLATION_ABOUT}</h2>
+            <p>{@html TRANSLATED.TRANSLATION_DRAFT}</p>
+            {#if currentLocale.wcagStatus === "unofficial"}
+              <p>{@html TRANSLATED.TRANSLATION_UNOFFICIAL}</p>
+            {/if}
+            <p>{@html TRANSLATED.TRANSLATION_ACK}</p>
           </section>
       {/if}
       <slot />
@@ -54,7 +60,7 @@
 </style>
 
 <script>
-  import { onMount } from "svelte";
+  import { onMount, getContext } from "svelte";
   import { useLocation } from 'svelte-navigator';
   import { honourFragmentIdLinks } from '@app/scripts/honourFragmentIdLinks.js';
   import { locale } from 'svelte-i18n';
@@ -62,7 +68,7 @@
   import locales from '@app/locales/index.json';
   $: currentLocale = locales.find((l) => l.lang === $locale);
 
-  import { routes, basepath, yourReportPanelOpen } from '@app/stores/appStore.js';
+  import { routes, yourReportPanelOpen } from '@app/stores/appStore.js';
 
   import YourReport from '@app/components/ui/YourReport.svelte';
 
@@ -80,4 +86,14 @@
   });
 
   export let title;
+
+  const { translate } = getContext('app');
+
+  $: TRANSLATED = {
+    TRANSLATION_ABOUT: $translate('UI.COMMON.TRANSLATION_ABOUT'),
+    TRANSLATION_DRAFT: $translate('UI.COMMON.TRANSLATION_DRAFT'),
+    TRANSLATION_ACK: $translate('UI.COMMON.TRANSLATION_ACK'),
+    TRANSLATION_UNOFFICIAL: $translate('UI.COMMON.TRANSLATION_UNOFFICIAL'),
+  };
+
 </script>

--- a/src/locales/en/UI/COMMON.json
+++ b/src/locales/en/UI/COMMON.json
@@ -25,5 +25,9 @@
     "DELETE": "Delete",
     "FOR": "for",
     "EXPAND_ALL": "Expand All Sections",
-    "COLLAPSE_ALL": "Collapse All Sections"
+    "COLLAPSE_ALL": "Collapse All Sections",
+    "TRANSLATION_ABOUT": "About this translation",
+    "TRANSLATION_DRAFT": "This volunteer translation is a <strong>draft</strong>. It contains English wording that will be translated soon.",
+    "TRANSLATION_ACK": "See <a href='https://www.w3.org/WAI/eval/report-tool/acknowledgements'>Acknowledgements</a> for all translators and contributors.",
+    "TRANSLATION_UNOFFICIAL": "This translation of WCAG 2 guidelines and success criteria is <strong>unofficial</strong> and might not accurately reflect the intentions of the <a href='https://www.w3.org/WAI/standards-guidelines/wcag/#versions'>English originals</a>."
 }

--- a/src/locales/fr/UI/COMMON.json
+++ b/src/locales/fr/UI/COMMON.json
@@ -25,5 +25,9 @@
     "DELETE": "Supprimer",
     "FOR": "pour",
     "EXPAND_ALL": "Afficher toutes les sections",
-    "COLLAPSE_ALL": "Masquer toutes les sections"
+    "COLLAPSE_ALL": "Masquer toutes les sections",
+    "TRANSLATION_ABOUT": "À propos de cette traduction",
+    "TRANSLATION_DRAFT": "Cette traduction faite par des volontaires est au statut de <strong>brouillon</strong>. Elle contient des termes en anglais qui seront traduits prochainement.",
+    "TRANSLATION_ACK": "Consultez la liste des traducteurs et contributeurs dans la page <a href='https://www.w3.org/WAI/eval/report-tool/acknowledgements'>Remerciements</a>.",
+    "TRANSLATION_UNOFFICIAL": "Cette traduction des règles et des critères de succès des WCAG 2 est <strong>non-officielle</strong> et pourrait ne pas réfleter les intentions des <a href='https://www.w3.org/WAI/standards-guidelines/wcag/#versions'>originaux en anglais</a>."
 }

--- a/src/locales/index.json
+++ b/src/locales/index.json
@@ -16,6 +16,7 @@
     {
         "lang": "pl",
         "title": "Polski",
-        "status": "draft"
+        "status": "draft",
+        "wcagStatus": "unofficial"
     }
 ]


### PR DESCRIPTION
- When the translation of WCAG guidelines and success criteria is not based on a WCAG Authorized Translation, we display a message in the translation box:

  > This translation of WCAG 2 guidelines and success criteria is <strong>unofficial</strong> and might not accurately reflect the intentions of the <a href='https://www.w3.org/WAI/standards-guidelines/wcag/#versions'>English originals</a>

  I suggest using the plural  "English original<ins>**s**</ins>" since the wording comes from WCAG 2.0, 2.1 and 2.2.

  To add this message, add `"wcagStatus": "unofficial"` in `src/locales/index.json` (see Polish translation)

  Resolves https://github.com/w3c/wai-wcag-em-report-tool/issues/138

- Text in the translation box is now translatable (see French translation for example): just add and translate the following lines in `src/locales/<lang>/UI/COMMON.json`:

  ```
    "TRANSLATION_ABOUT": "About this translation",
    "TRANSLATION_DRAFT": "This volunteer translation is a <strong>draft</strong>. It contains English wording that will be translated soon.",
    "TRANSLATION_ACK": "See <a href='https://www.w3.org/WAI/eval/report-tool/acknowledgements'>Acknowledgements</a> for all translators and contributors.",
    "TRANSLATION_UNOFFICIAL": "This translation of WCAG 2 guidelines and success criteria is <strong>unofficial</strong> and might not accurately reflect the intentions of the <a href='https://www.w3.org/WAI/standards-guidelines/wcag/#versions'>English originals</a>."
  ```

  <img width="653" alt="Disclaimer box example" src="https://github.com/w3c/wai-wcag-em-report-tool/assets/7482063/ecc3648f-7e8e-435b-ba3b-d12a6bfdc618">