### PR TITLE
Add wcag.json update script and apply update

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/Erbium
+lts/erbium

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "WCAG-EM-Report-Tool",
-  "version": "2.0.1",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1351,6 +1351,31 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
+    "axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+          "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -1430,6 +1455,24 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.0"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+          "dev": true
+        }
       }
     },
     "callsites": {
@@ -1669,6 +1712,17 @@
         "esutils": "^2.0.2"
       }
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1724,6 +1778,71 @@
         "object.assign": "^4.1.0",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+          "dev": true
+        },
+        "get-intrinsic": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+          "dev": true,
+          "requires": {
+            "call-bind-apply-helpers": "^1.0.2",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.1.1",
+            "function-bind": "^1.1.2",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "math-intrinsics": "^1.1.0"
+          }
+        },
+        "has-symbols": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+          "dev": true
+        }
       }
     },
     "es-to-primitive": {
@@ -2123,6 +2242,12 @@
       "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2193,6 +2318,16 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
       "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -2267,6 +2402,12 @@
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -2305,6 +2446,40 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.3"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+          "dev": true
+        }
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+          "dev": true
+        }
+      }
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -2742,6 +2917,12 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
       "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw=="
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
+    },
     "memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -3098,6 +3279,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "dev": "export BASEPATH='' && npm run clean:dev & rollup -c -w",
         "clean": "rimraf ./build ./node_modules",
         "clean:build": "rimraf ./build",
-        "clean:dev": "rimraf ./build"
+        "clean:dev": "rimraf ./build",
+        "json": "node update-wcag-json.mjs"
     },
     "main": "src/main.js",
     "dependencies": {
@@ -34,6 +35,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^8.0.0",
         "@rollup/plugin-replace": "^2.3.3",
+        "axios": "^1.8.4",
         "colors": "^1.4.0",
         "deepmerge": "^4.2.2",
         "eslint": "^7.15.0",

--- a/src/data/wcag.json
+++ b/src/data/wcag.json
@@ -432,7 +432,11 @@
             "id": "images-of-text-no-exception",
             "conformanceLevel": "AAA"
         },
-        "1.4.10": { "num": "1.4.10", "id": "reflow", "conformanceLevel": "AA" },
+        "1.4.10": {
+            "num": "1.4.10",
+            "id": "reflow",
+            "conformanceLevel": "AA"
+        },
         "1.4.11": {
             "num": "1.4.11",
             "id": "non-text-contrast",
@@ -448,7 +452,11 @@
             "id": "content-on-hover-or-focus",
             "conformanceLevel": "AA"
         },
-        "2.1.1": { "num": "2.1.1", "id": "keyboard", "conformanceLevel": "A" },
+        "2.1.1": {
+            "num": "2.1.1",
+            "id": "keyboard",
+            "conformanceLevel": "A"
+        },
         "2.1.2": {
             "num": "2.1.2",
             "id": "no-keyboard-trap",
@@ -619,8 +627,16 @@
             "id": "pronunciation",
             "conformanceLevel": "AAA"
         },
-        "3.2.1": { "num": "3.2.1", "id": "on-focus", "conformanceLevel": "A" },
-        "3.2.2": { "num": "3.2.2", "id": "on-input", "conformanceLevel": "A" },
+        "3.2.1": {
+            "num": "3.2.1",
+            "id": "on-focus",
+            "conformanceLevel": "A"
+        },
+        "3.2.2": {
+            "num": "3.2.2",
+            "id": "on-input",
+            "conformanceLevel": "A"
+        },
         "3.2.3": {
             "num": "3.2.3",
             "id": "consistent-navigation",
@@ -656,13 +672,21 @@
             "id": "error-prevention-legal-financial-data",
             "conformanceLevel": "AA"
         },
-        "3.3.5": { "num": "3.3.5", "id": "help", "conformanceLevel": "AAA" },
+        "3.3.5": {
+            "num": "3.3.5",
+            "id": "help",
+            "conformanceLevel": "AAA"
+        },
         "3.3.6": {
             "num": "3.3.6",
             "id": "error-prevention-all",
             "conformanceLevel": "AAA"
         },
-        "4.1.1": { "num": "4.1.1", "id": "parsing", "conformanceLevel": "A" },
+        "4.1.1": {
+            "num": "4.1.1",
+            "id": "parsing",
+            "conformanceLevel": "A"
+        },
         "4.1.2": {
             "num": "4.1.2",
             "id": "name-role-value",
@@ -800,7 +824,11 @@
             "id": "images-of-text-no-exception",
             "conformanceLevel": "AAA"
         },
-        "1.4.10": { "num": "1.4.10", "id": "reflow", "conformanceLevel": "AA" },
+        "1.4.10": {
+            "num": "1.4.10",
+            "id": "reflow",
+            "conformanceLevel": "AA"
+        },
         "1.4.11": {
             "num": "1.4.11",
             "id": "non-text-contrast",
@@ -816,7 +844,11 @@
             "id": "content-on-hover-or-focus",
             "conformanceLevel": "AA"
         },
-        "2.1.1": { "num": "2.1.1", "id": "keyboard", "conformanceLevel": "A" },
+        "2.1.1": {
+            "num": "2.1.1",
+            "id": "keyboard",
+            "conformanceLevel": "A"
+        },
         "2.1.2": {
             "num": "2.1.2",
             "id": "no-keyboard-trap",
@@ -927,6 +959,21 @@
             "id": "section-headings",
             "conformanceLevel": "AAA"
         },
+        "2.4.11": {
+            "num": "2.4.11",
+            "id": "focus-not-obscured-minimum",
+            "conformanceLevel": "AA"
+        },
+        "2.4.12": {
+            "num": "2.4.12",
+            "id": "focus-not-obscured-enhanced",
+            "conformanceLevel": "AAA"
+        },
+        "2.4.13": {
+            "num": "2.4.13",
+            "id": "focus-appearance",
+            "conformanceLevel": "AAA"
+        },
         "2.5.1": {
             "num": "2.5.1",
             "id": "pointer-gestures",
@@ -949,13 +996,23 @@
         },
         "2.5.5": {
             "num": "2.5.5",
-            "id": "target-size",
+            "id": "target-size-enhanced",
             "conformanceLevel": "AAA"
         },
         "2.5.6": {
             "num": "2.5.6",
             "id": "concurrent-input-mechanisms",
             "conformanceLevel": "AAA"
+        },
+        "2.5.7": {
+            "num": "2.5.7",
+            "id": "dragging-movements",
+            "conformanceLevel": "AA"
+        },
+        "2.5.8": {
+            "num": "2.5.8",
+            "id": "target-size-minimum",
+            "conformanceLevel": "AA"
         },
         "3.1.1": {
             "num": "3.1.1",
@@ -987,8 +1044,16 @@
             "id": "pronunciation",
             "conformanceLevel": "AAA"
         },
-        "3.2.1": { "num": "3.2.1", "id": "on-focus", "conformanceLevel": "A" },
-        "3.2.2": { "num": "3.2.2", "id": "on-input", "conformanceLevel": "A" },
+        "3.2.1": {
+            "num": "3.2.1",
+            "id": "on-focus",
+            "conformanceLevel": "A"
+        },
+        "3.2.2": {
+            "num": "3.2.2",
+            "id": "on-input",
+            "conformanceLevel": "A"
+        },
         "3.2.3": {
             "num": "3.2.3",
             "id": "consistent-navigation",
@@ -1003,6 +1068,11 @@
             "num": "3.2.5",
             "id": "change-on-request",
             "conformanceLevel": "AAA"
+        },
+        "3.2.6": {
+            "num": "3.2.6",
+            "id": "consistent-help",
+            "conformanceLevel": "A"
         },
         "3.3.1": {
             "num": "3.3.1",
@@ -1024,51 +1094,15 @@
             "id": "error-prevention-legal-financial-data",
             "conformanceLevel": "AA"
         },
-        "3.3.5": { "num": "3.3.5", "id": "help", "conformanceLevel": "AAA" },
+        "3.3.5": {
+            "num": "3.3.5",
+            "id": "help",
+            "conformanceLevel": "AAA"
+        },
         "3.3.6": {
             "num": "3.3.6",
             "id": "error-prevention-all",
             "conformanceLevel": "AAA"
-        },
-        "4.1.2": {
-            "num": "4.1.2",
-            "id": "name-role-value",
-            "conformanceLevel": "A"
-        },
-        "4.1.3": {
-            "num": "4.1.3",
-            "id": "status-messages",
-            "conformanceLevel": "AA"
-        },
-        "2.4.11": {
-            "num": "2.4.11",
-            "id": "focus-not-obscured-minimum",
-            "conformanceLevel": "AA"
-        },
-        "2.4.12": {
-            "num": "2.4.12",
-            "id": "focus-not-obscured-enhanced",
-            "conformanceLevel": "AAA"
-        },
-        "2.4.13": {
-            "num": "2.4.13",
-            "id": "focus-appearance",
-            "conformanceLevel": "AAA"
-        },
-        "2.5.7": {
-            "num": "2.5.7",
-            "id": "dragging-movements",
-            "conformanceLevel": "AA"
-        },
-        "2.5.8": {
-            "num": "2.5.8",
-            "id": "target-size-minimum",
-            "conformanceLevel": "AA"
-        },
-        "3.2.6": {
-            "num": "3.2.6",
-            "id": "consistent-help",
-            "conformanceLevel": "A"
         },
         "3.3.7": {
             "num": "3.3.7",
@@ -1084,6 +1118,16 @@
             "num": "3.3.9",
             "id": "accessible-authentication-enhanced",
             "conformanceLevel": "AAA"
+        },
+        "4.1.2": {
+            "num": "4.1.2",
+            "id": "name-role-value",
+            "conformanceLevel": "A"
+        },
+        "4.1.3": {
+            "num": "4.1.3",
+            "id": "status-messages",
+            "conformanceLevel": "AA"
         }
     }
 }

--- a/update-wcag-json.mjs
+++ b/update-wcag-json.mjs
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+const wcagUrl = 'https://www.w3.org/WAI/WCAG$VERSION/wcag.json';
+
+(async () => {
+  const [wcag21, wcag22] = await Promise.all([
+    axios
+      .get(wcagUrl.replace('$VERSION', '21'), { responseType: 'json' })
+      .then(({ data }) => data),
+    axios
+      .get(wcagUrl.replace('$VERSION', '22'), { responseType: 'json' })
+      .then(({ data }) => data)
+  ]);
+
+  function mapVersion(data, version) {
+    const map = {};
+    for (const principle of data.principles) {
+      for (const guideline of principle.guidelines) {
+        for (const criterion of guideline.successcriteria) {
+          if (criterion.versions.includes(version)) {
+            map[criterion.num] = {
+              num: criterion.num,
+              id:
+                version === '2.0' && criterion.alt_id.length
+                  ? criterion.alt_id[0]
+                  : criterion.id,
+              conformanceLevel: criterion.level
+            };
+          }
+        }
+      }
+    }
+    return map;
+  }
+
+  const data = {
+    '2.0': mapVersion(wcag21, '2.0'),
+    2.1: mapVersion(wcag21, '2.1'),
+    2.2: mapVersion(wcag22, '2.2')
+  };
+
+  writeFileSync(
+    join('src', 'data', 'wcag.json'),
+    JSON.stringify(data, null, '    ') + '\n'
+  );
+})();


### PR DESCRIPTION
This adds a script that processes the `wcag.json` files under `w3.org/WAI/WCAG2x` into the format of this repository's `src/data/wcag.json`, and includes updates from running the script.

Tested with Node v12 as well as v20, since the former is what this repository's `package.json` specifies. The script is wrapped in an async function for that reason, since top-level async wasn't avaiable in v12.

The JSON itself remains largely intact with the update; most of the changes are in formatting or ordering. The only substantial change is the correction of the ID for `target-size-enhanced` in 2.2.