### PR TITLE
docs: fix name in intro and make consistent

### DIFF
--- a/src/locales/en/PAGES/START.json
+++ b/src/locales/en/PAGES/START.json
@@ -2,7 +2,7 @@
     "TITLE": "WCAG-EM Report Tool",
     "SUBTITLE": "Overview",
     "INTRO_HD": "What this tool does",
-    "INTRO_1": "WCAG-EM Report Tool turns your accessibility evaluation findings into a report. It is based on the Web Content Accessibility Guidelines Evaluation Methodology ([WCAG-EM](https://www.w3.org/TR/WCAG-EM/)).",
+    "INTRO_1": "WCAG-EM Report Tool turns your accessibility evaluation findings into a report. It is based on the Website Accessibility Conformance Evaluation Methodology ([WCAG-EM](https://www.w3.org/TR/WCAG-EM/)).",
     "TIPS_HD": "Tips for using this tool",
     "TIPS_1": "Under “View Report”, you can download your report as HTML (web page) or as JSON (structured data).",
     "TIPS_2": "You can format your findings with <a href='https://en.wikipedia.org/wiki/Markdown'>Markdown</a>, to add lists, links and code examples and more. This also works on the 'Executive summary' and 'Evaluation specifics' fields.",

--- a/src/locales/nl/PAGES/START.json
+++ b/src/locales/nl/PAGES/START.json
@@ -2,7 +2,7 @@
     "TITLE": "WCAG-EM Report Tool",
     "SUBTITLE": "Overzicht",
     "INTRO_HD": "Wat de tool doet",
-    "INTRO_1": "Deze tool maakt een rapport op basis van uw bevindingen in toegankelijkheidsonderzoek. Het is gebaseerd op de [Web Content Accessibility Guidelines Evaluation Methodology (WCAG-EM)](https://www.w3.org/TR/WCAG-EM/).",
+    "INTRO_1": "Deze tool maakt een rapport op basis van uw bevindingen in toegankelijkheidsonderzoek. Het is gebaseerd op de Website Accessibility Conformance Evaluation Methodology ([WCAG-EM](https://www.w3.org/TR/WCAG-EM/)).",
     "TIPS_HD": "Tips voor het gebruik van deze tool",
     "TIPS_1": "Onder “Bekijk Report”, kunt u uw rapport downloaden als HTML (webpagina) of als JSON (gestructureerde data).",
     "TIPS_2": "U kunt bevindingen beschrijven in  <a href='https://en.wikipedia.org/wiki/Markdown'>Markdown</a>, zodat u bijvoorbeeld lijsten, links en codevoorbeelden kunt toevoegen. Dit werkt ook op de velden 'managementsamenvatting' en 'onderbouwing van de evaluatie'.",


### PR DESCRIPTION
As reported by @julezrulez in https://github.com/w3c/wai-wcag-em-report-tool/issues/202, the name of the methodology was listed wrong in the intro, both in the English and Dutch version. 

This PR fixes that, and also makes the link in the Dutch consistent with how it is in the English version (with only the 'WCAG-EM' portion linking out).