### PR TITLE
fix: render a space to match markup on WAI site

### DIFF
--- a/src/components/ui/LanguageSelect.svelte
+++ b/src/components/ui/LanguageSelect.svelte
@@ -10,7 +10,7 @@
         class="LanguageSelect__languages languagelistul"
         on:click="{handleClick}"
       >
-        {#each locales as appLocale}
+        {#each locales as appLocale, index}
           <li
             class="LanguageSelect__language {appLocale === currentLocale ? 'language__item--current' : ''}"
           >
@@ -22,7 +22,7 @@
                 href="#{appLocale.lang}"
               >{appLocale.title}</a>
             {/if}
-          </li>
+          </li>{index > 0 ? " " : ""}
         {/each}
       </ul>
     </span>


### PR DESCRIPTION
The list of languages at the top relies on WAI website CSS. The WAI website has whitespace between navigation items, the report tool does not.

This PR adds a space to all but the first language, so that the spacing looks like it does on the WAI website. 

fixes https://github.com/w3c/wai-wcag-em-report-tool/issues/205

## Before

<img width="674" height="46" alt="screenshot of language select with spacer between items positioned directly next to item text, leaving no space" src="https://github.com/user-attachments/assets/c4761eb1-c3b0-41db-a6d6-d5ba51b6cf73" />

## After

<img width="336" height="24" alt="like above but with consistent spaces" src="https://github.com/user-attachments/assets/bc3a6f65-5512-4afa-97ce-3b75f444d4f8" />

