### PR TITLE
Fix broken links in YourReport

### DIFF
--- a/src/components/ui/YourReport.svelte
+++ b/src/components/ui/YourReport.svelte
@@ -66,7 +66,7 @@
   import assertions from '@app/stores/earl/assertionStore/index.js';
   import evaluationStore from '@app/stores/evaluationStore.js';
 
-  import subjects, { TestSubjectTypes } from '@app/stores/earl/subjectStore/index.js';
+  import { TestSubjectTypes } from '@app/stores/earl/subjectStore/index.js';
   import { CriteriaSelected } from '@app/stores/selectedCriteriaStore.js';
   let criteriaCount = 0;
   $: criteriaCount = $CriteriaSelected.length;
@@ -173,11 +173,9 @@
       }
   }
 
-  $: isOverview = $location.pathname === $routes.OVERVIEW.path; 
-  $: isAuditSample = $location.pathname === $routes.AUDIT.path; 
+  $: isOverview = $location.pathname === $routes.OVERVIEW.path;
+  $: isAuditSample = $location.pathname === $routes.AUDIT.path;
   $: siteName = $scopeStore['SITE_NAME'];
-  $: totalToEvaluate = $assertions.filter(assertion => 
-    assertion.result.outcome.id == "earl:untested").length;
   $: totalEvaluated = $assertions.filter(assertion => 
     assertion.result.outcome.id !== "earl:untested" && assertion.subject.type.indexOf(TestSubjectTypes.WEBSITE) >= 0).length;
 </script>

--- a/src/components/ui/YourReport.svelte
+++ b/src/components/ui/YourReport.svelte
@@ -9,7 +9,7 @@
       <li class="progress">
         <div class="progress__principle">
           {#if isAuditSample}
-          <a href={`/evaluation/audit-sample#principle-${TRANSLATED.PRINCIPLES[principle].TITLE.toLowerCase()}`} class="principle__name">
+          <a href={`#principle-${TRANSLATED.PRINCIPLES[principle].TITLE.toLowerCase()}`} class="principle__name">
             <span>{TRANSLATED.PRINCIPLES[principle].TITLE}</span>
           </a>
           {:else}


### PR DESCRIPTION
This PR fixes broken “Your report" criteria links in the "Audit Sample" tab.

<img width="1396" height="737" alt="image" src="https://github.com/user-attachments/assets/eccb2960-e3ab-4b37-ad43-b3c5de410e4c" />

The issue occurred when a `BASEPATH` variable was configured for [publishing the report tool in a subfolder.](https://github.com/w3c/wai-wcag-em-report-tool?tab=readme-ov-file#publishing-in-a-sub-folder)

It is also present on the officially published [WCAG-EM Report Tool ](https://www.w3.org/WAI/eval/report-tool/evaluation/audit-sample) website.

In addition, this PR includes a small cleanup removing unused variables (`subjects` and `totalToEvaluate`) from the `YourReport` component.

Fixes #288 .