### PR TITLE
Upgrade actions to use recent versions relying on Node v24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Use Node.js '12.x'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '12.x'
     - run: npm install
@@ -26,12 +26,12 @@ jobs:
     - run: export BASEPATH='/WAI/eval/report-tool' && npm run clean:build && rollup -c
     - run: cd build && ln -s index.html 404.html # symlink for GH pages fallback
     - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@4.1.4
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         BRANCH: gh-pages
         FOLDER: build
     - name: Create zip file 🗂
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: build/
         dest: result.zip 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout 🛎️
@@ -31,7 +33,7 @@ jobs:
         BRANCH: gh-pages
         FOLDER: build
     - name: Create zip file 🗂
-      uses: vimtor/action-zip@v1
+      uses: vimtor/action-zip@v1.3
       with:
         files: build/
         dest: result.zip 


### PR DESCRIPTION
This resolves warnings about actions that rely on Node v20.

[Example run on fork](https://github.com/kfranqueiro/wai-wcag-em-report-tool/actions/runs/27633764514/job/81715390933) which was mostly successful except for pushing to github, which I presume is relying on permissions that a fork doesn't have by default

(Note RE the action-zip change: the repo moved, but the latest version is still 1.x, updated to use Node 24 in March)