### PR TITLE
fix(view-report): fix visual overlapping header bug

### DIFF
--- a/src/components/ui/Report/ReportAllResults.svelte
+++ b/src/components/ui/Report/ReportAllResults.svelte
@@ -119,6 +119,7 @@
   .Auditor__ResultsTableHeader {
     position: sticky;
     top: 0;
+    z-index: 1;
   }
   .Auditor__Assertion {
     margin-bottom: 1em;


### PR DESCRIPTION
Fixes #280 

## Problem
The view-report header visually overlaps cell content when sticky causing obfuscation of content and allows interaction of the "edit" button from inside the header area when overlapped. 


## Solution
Added z-index to the header to ensure it is rendered properly above the cell content in the UI. 

## Testing
Tested in Firefox, Chrome, Edge.

## Screenshots

Broken (original, current on issue 280):
<img width="1708" height="676" alt="image" src="https://github.com/user-attachments/assets/5ee96341-56b3-43e3-90ee-4e64433cea9b" />

Fixed:
<img width="1423" height="531" alt="image" src="https://github.com/user-attachments/assets/97538532-b6f6-49d5-af9d-a5ed08c4a2d3" />
