### PR TITLE
Add a note that explains the tool is now based on WCAG-EM 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "WCAG-EM-Report-Tool",
-    "version": "3.0.3",
+    "version": "5.0.0",
     "repository": {
         "type": "git",
         "url": "git://github.com/w3c/wcag-em-report-tool.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "WCAG-EM-Report-Tool",
-    "version": "5.0.0",
+    "version": "4.1.0",
     "repository": {
         "type": "git",
         "url": "git://github.com/w3c/wcag-em-report-tool.git"

--- a/src/components/pages/OverviewPage.svelte
+++ b/src/components/pages/OverviewPage.svelte
@@ -3,7 +3,13 @@
  *   OverviewPage
  * -->
 <Page title="{TRANSLATED.PAGE_TITLE}" pageid="overview">
-
+  {#if !$welcomeMsgDismissed}
+  <div style="background: var(--footer-grey); border: 0; padding: 1em; display: flex; align-items: center" lang="en">
+    <p style="max-width: none; margin: 0;">
+      {@html TRANSLATED.WELCOME_MESSAGE}
+    </p>
+    <button on:click="{dismissWelcomeMessage}" style="margin-left: 1em;" type="button" class="button-secondary">Dismiss</button>  </div>
+  {/if}
   <div class="getting-started">
     <p class="getting-started__intro">
       {@html TRANSLATED.INTRODUCTION_P1}
@@ -55,7 +61,7 @@
   import OpenEvaluation from '@app/components/form/OpenEvaluation.svelte';
   import Button from '@app/components/ui/Button.svelte';
 
-  import { routes } from '@app/stores/appStore.js';
+  import { routes, welcomeMsgDismissed } from '@app/stores/appStore.js';
   import evaluationStore from '@app/stores/evaluationStore.js';
   import { interacted } from '@app/stores/interactedStore.js';
 
@@ -91,7 +97,8 @@
     CHOICES_DD4: $translate('PAGES.START.CHOICES_DD4'),
     CHOICES_DT5: $translate('PAGES.START.CHOICES_DT5'),
     CHOICES_DD5: $translate('PAGES.START.CHOICES_DD5'),
-    CLEAR_WARNING: $translate('UI.NAV.CLEARWARNING')
+    CLEAR_WARNING: $translate('UI.NAV.CLEARWARNING'),
+    WELCOME_MESSAGE: $translate('PAGES.START.WELCOME_MESSAGE')
   };
 
   function handleNewEvaluationClick() {
@@ -108,6 +115,10 @@
     }
   }
 
+ function dismissWelcomeMessage() {
+    welcomeMsgDismissed.update(() => true);
+    localStorage.setItem('welcomeMsgDismissed', 'true');
+  }
 </script>
 
 <style>

--- a/src/index.html
+++ b/src/index.html
@@ -46,14 +46,14 @@
               Please share your ideas, suggestions, or comments via e-mail to
               the publicly-archived list
               <a
-                href="mailto:wai@w3.org?subject=[en]%20WCAG-EM%20Report%20Tool"
+                href="mailto:wai@w3.org?body=%5Binclude%20a%20relevant%20email%20Subject%5D%0A%0A%5Bput%20comment%20here...%5D%0A%0AI%20give%20permission%20to%20share%20this%20to%20a%20publicly-archived%20e-mail%20list."
                 >wai@w3.org</a
               >
               or via GitHub.
             </p>
             <div class="button-group">
               <a
-                href="mailto:wai-eo-editors@w3.org?subject=[en]%20WCAG-EM%20Report%20Tool&amp;body=[put%20comment%20here...]"
+                href="mailto:wai@w3.org?body=%5Binclude%20a%20relevant%20email%20Subject%5D%0A%0A%5Bput%20comment%20here...%5D%0A%0AI%20give%20permission%20to%20share%20this%20to%20a%20publicly-archived%20e-mail%20list."
                 class="button"
                 ><span>E-mail</span></a
               >

--- a/src/index.html
+++ b/src/index.html
@@ -82,7 +82,7 @@
           "
         >    
           <p>
-            <strong>Status:</strong> Updated {__APP_BUILD_DATE__}, Version {__APP_VERSION__}. <a href="https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog:-What's-new-in-the-2021-redesign-of-the-WCAG-EM-Report-Tool">Changelog</a>. <a href="https://w3c.github.io/wcag-em-report-tool/">Previous version</a>.
+            <strong>Status:</strong> Updated {__APP_BUILD_DATE__}, Version {__APP_VERSION__}. <a href="https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog">Changelog</a>.
           </p>
 
           <p>

--- a/src/index.html
+++ b/src/index.html
@@ -46,8 +46,8 @@
               Please share your ideas, suggestions, or comments via e-mail to
               the publicly-archived list
               <a
-                href="mailto:wai-eo-editors@w3.org?subject=[en]%20WCAG-EM%20Report%20Tool"
-                >wai-eo-editors@w3.org</a
+                href="mailto:wai@w3.org?subject=[en]%20WCAG-EM%20Report%20Tool"
+                >wai@w3.org</a
               >
               or via GitHub.
             </p>

--- a/src/index.html
+++ b/src/index.html
@@ -82,7 +82,7 @@
           "
         >    
           <p>
-            <strong>Status:</strong> Updated {__APP_BUILD_DATE__}, Version {__APP_VERSION__}. <a href="https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog">Changelog</a>.
+            <strong>Status:</strong> Updated {__APP_BUILD_DATE__}, Version {__APP_VERSION__}. <a href="https://github.com/w3c/wai-wcag-em-report-tool/releases">Changelog</a>.
           </p>
 
           <p>

--- a/src/locales/en/PAGES/START.json
+++ b/src/locales/en/PAGES/START.json
@@ -26,5 +26,5 @@
     "CHOICES_DD4": "This success criterion relates to a feature the authoring tool does not have, it does not apply. ",
     "CHOICES_DT5": "Cannot tell",
     "CHOICES_DD5": "It is unclear whether the success criterion is met.",
-    "WELCOME_MESSAGE": "<strong>Note:</strong> The WCAG-EM Report Tool now uses the terminology defined in <a href='https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/#versiondiff'>WCAG-EM 2</a>. The tool can be used to evaluate websites, apps, and other digital products. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>."
+    "WELCOME_MESSAGE": "<strong>Note:</strong> The WCAG-EM Report Tool now uses the terminology defined in <a href='https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/#versiondiff'>WCAG-EM 2</a>. The tool can be used to evaluate websites, apps, and other digital products. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/releases/tag/4.1.0'>changelog</a>."
 }

--- a/src/locales/en/PAGES/START.json
+++ b/src/locales/en/PAGES/START.json
@@ -25,5 +25,6 @@
     "CHOICES_DT4": "Not applicable",
     "CHOICES_DD4": "This success criterion relates to a feature the authoring tool does not have, it does not apply. ",
     "CHOICES_DT5": "Cannot tell",
-    "CHOICES_DD5": "It is unclear whether the success criterion is met."
+    "CHOICES_DD5": "It is unclear whether the success criterion is met.",
+    "WELCOME_MESSAGE": "<strong>Note:</strong> The WCAG-EM Report Tool now uses the terminology defined in <a href='https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/#versiondiff'>WCAG-EM 2</a>. The tool can be used to evaluate websites, apps and other digital products. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>."
 }

--- a/src/locales/en/PAGES/START.json
+++ b/src/locales/en/PAGES/START.json
@@ -26,5 +26,5 @@
     "CHOICES_DD4": "This success criterion relates to a feature the authoring tool does not have, it does not apply. ",
     "CHOICES_DT5": "Cannot tell",
     "CHOICES_DD5": "It is unclear whether the success criterion is met.",
-    "WELCOME_MESSAGE": "<strong>Note:</strong> The WCAG-EM Report Tool now uses the terminology defined in <a href='https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/#versiondiff'>WCAG-EM 2</a>. The tool can be used to evaluate websites, apps and other digital products. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>."
+    "WELCOME_MESSAGE": "<strong>Note:</strong> The WCAG-EM Report Tool now uses the terminology defined in <a href='https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/#versiondiff'>WCAG-EM 2</a>. The tool can be used to evaluate websites, apps, and other digital products. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>."
 }

--- a/src/locales/fr/PAGES/START.json
+++ b/src/locales/fr/PAGES/START.json
@@ -25,5 +25,6 @@
     "CHOICES_DT4": "Non applicable",
     "CHOICES_DD4": "Ce critère de réussite se rapporte à une fonctionnalité que l’outil de création ne possède pas, il n’est donc pas applicable. ",
     "CHOICES_DT5": "Je ne sais pas",
-    "CHOICES_DD5": "Il n’est pas certain que le critère de réussite soit rempli."
+    "CHOICES_DD5": "Il n’est pas certain que le critère de réussite soit rempli.",
+    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The French translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>.</span>"
 }

--- a/src/locales/fr/PAGES/START.json
+++ b/src/locales/fr/PAGES/START.json
@@ -26,5 +26,5 @@
     "CHOICES_DD4": "Ce critère de réussite se rapporte à une fonctionnalité que l’outil de création ne possède pas, il n’est donc pas applicable. ",
     "CHOICES_DT5": "Je ne sais pas",
     "CHOICES_DD5": "Il n’est pas certain que le critère de réussite soit rempli.",
-    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The French translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>.</span>"
+    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The French translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/releases/tag/4.1.0'>changelog</a>.</span>"
 }

--- a/src/locales/nl/PAGES/START.json
+++ b/src/locales/nl/PAGES/START.json
@@ -16,5 +16,6 @@
     "USAGE_LI3": "U kunt tussentijdse rapporten bewaren en er later aan verder werken. Gebruik de ‘Open Rapport’ knop op de eerste pagina en laad daar het bestand dat u eerder hebt opgeslagen.",
     "USAGE_LI4": "Links naar externe pagina’s (buiten de tool) openen in een nieuw browser venster.",
     "TIPS_HD": "Tips om de tool te gebruiken",
-    "TIPS_LI3": "De tool creëert uw rapport als HTML en CSS bestanden. U kunt deze bestanden downloaden op de ‘Bekijk rapport’-pagina. Daarna kunt u de presentatie en de inhoud van het rapport verder bewerken."
+    "TIPS_LI3": "De tool creëert uw rapport als HTML en CSS bestanden. U kunt deze bestanden downloaden op de ‘Bekijk rapport’-pagina. Daarna kunt u de presentatie en de inhoud van het rapport verder bewerken.",
+    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The Dutch translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>.</span>"
 }

--- a/src/locales/nl/PAGES/START.json
+++ b/src/locales/nl/PAGES/START.json
@@ -17,5 +17,5 @@
     "USAGE_LI4": "Links naar externe pagina’s (buiten de tool) openen in een nieuw browser venster.",
     "TIPS_HD": "Tips om de tool te gebruiken",
     "TIPS_LI3": "De tool creëert uw rapport als HTML en CSS bestanden. U kunt deze bestanden downloaden op de ‘Bekijk rapport’-pagina. Daarna kunt u de presentatie en de inhoud van het rapport verder bewerken.",
-    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The Dutch translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>.</span>"
+    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The Dutch translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/releases/tag/4.1.0'>changelog</a>.</span>"
 }

--- a/src/locales/pl/PAGES/START.json
+++ b/src/locales/pl/PAGES/START.json
@@ -26,5 +26,5 @@
     "CHOICES_DD4": "To kryterium sukcesu nie ma zastosowania - odnosi się do funkcji lub treści, jakiej nie ma na stronie. ",
     "CHOICES_DT5": "Nie można powiedzieć",
     "CHOICES_DD5": "Nie wiadomo, czy kryterium sukcesu jest spełnione",
-    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The Polish translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>.</span>"
+    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The Polish translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/releases/tag/4.1.0'>changelog</a>.</span>"
 }

--- a/src/locales/pl/PAGES/START.json
+++ b/src/locales/pl/PAGES/START.json
@@ -25,5 +25,6 @@
     "CHOICES_DT4": "Nie dotyczy",
     "CHOICES_DD4": "To kryterium sukcesu nie ma zastosowania - odnosi się do funkcji lub treści, jakiej nie ma na stronie. ",
     "CHOICES_DT5": "Nie można powiedzieć",
-    "CHOICES_DD5": "Nie wiadomo, czy kryterium sukcesu jest spełnione"
+    "CHOICES_DD5": "Nie wiadomo, czy kryterium sukcesu jest spełnione",
+    "WELCOME_MESSAGE": "<span lang='en'><strong>Note:</strong> The Polish translation of the WCAG-EM Report Tool is currently based on WCAG-EM 1. The English version is based on WCAG-EM 2. For the list of changes, see the <a href='https://github.com/w3c/wai-wcag-em-report-tool/wiki/Changelog'>changelog</a>.</span>"
 }

--- a/src/stores/appStore.js
+++ b/src/stores/appStore.js
@@ -38,6 +38,10 @@ export const routes = derived([translate], ([$translate]) => {
   };
 });
 
+export const welcomeMsgDismissed = writable(
+  localStorage.getItem('welcomeMsgDismissed') === 'true'
+);
+
 export const yourReportPanelOpen = writable(true);
 
 export const basepath = writable(true);


### PR DESCRIPTION
This PR adds a dismissible note on the start page, in each language:
 -  On the English version, the note indicates that the tool now uses the terminology defined in WCAG-EM 2, and points to the description of the release for the list of changes.
 - On the Dutch, French, and Polish versions, the note indicates that the translation is based on WCAG-EM 1 while the English version is based on WCAG-EM 2. It also points to the description of the release.

This re-implements some code that was previously used for the "new version" banner: https://github.com/w3c/wai-wcag-em-report-tool/pull/269.

Dependency: This PR needs to be published alongside https://github.com/w3c/wai-wcag-em-report-tool/pull/300
